### PR TITLE
Adds support for fetching binary data to fetch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ All rights reserved.
 
 ## Changelog
 
+### 4.10.0
+
+* Adds support for res.arrayBuffer() to react-storefront's internal fetch implementation.  This allows developers to fetch binary data as a buffer.
+
 ### 4.9.0
 
 * Prefetching now ramps up over the course of 25 minutes by default to ease the load on servers after clearing the cache during deployment

--- a/packages/react-storefront/src/fetch.js
+++ b/packages/react-storefront/src/fetch.js
@@ -107,7 +107,7 @@ export default function fetch(url, options, qsOptions) {
 
       relaySetCookies(response, requestOptions.hostname)
 
-      response.on('data', chunk => data.push(Buffer.from(chunk, 'binary')))
+      response.on('data', chunk => data.push(chunk))
 
       response.on('end', () => {
         data = Buffer.concat(data)

--- a/packages/react-storefront/src/fetch.js
+++ b/packages/react-storefront/src/fetch.js
@@ -72,6 +72,22 @@ export function fetchWithCookies(url, options = {}, qsOptions) {
 
 /**
  * An implementation of the standard fetch API.  See https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API for options
+ * 
+ * This function is commonly used to fetch json data:
+ * 
+ *  const data = await fetch('https://jsonplaceholder.typicode.com/todos/1')
+ *    .then(res => res.json())
+ * 
+ * ... or string data:
+ * 
+ *  const text = await fetch('https://jsonplaceholder.typicode.com/todos/1')
+ *    .then(res => res.text())
+ *
+ * ... but you can also use it to fetch binary data:
+ * 
+ *  const buffer = await fetch('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf')
+ *    .then(res => res.arrayBuffer())
+ * 
  * @param {String} url 
  * @param {Object} options Options for fetch
  * @param {String} qsOptions Options for serializing the request body using the qs package
@@ -82,17 +98,19 @@ export default function fetch(url, options, qsOptions) {
     const protocol = url.match(/^https/) ? global.https : global.http
     const { body, ...requestOptions } = createRequestOptions(url, options, qsOptions)
 
+    // use native node buffer, not webpack's shim, so it can be passed with response.send() on Moov XDN
+    const Buffer = global.Buffer
+
     // Moov should inject this via the Server component
     const req = protocol.request(requestOptions, response => {
       let data = []
-      response.setEncoding('utf8')
 
       relaySetCookies(response, requestOptions.hostname)
 
-      response.on('data', chunk => data.push(chunk))
+      response.on('data', chunk => data.push(Buffer.from(chunk, 'binary')))
 
       response.on('end', () => {
-        data = data.join('')
+        data = Buffer.concat(data)
 
         const ok = response.statusCode >= 200 && response.statusCode <= 299
 
@@ -114,12 +132,13 @@ export default function fetch(url, options, qsOptions) {
           status: response.statusCode,
           ok,
           headers: response.headers,
-          text: () => Promise.resolve(data),
-          json: () => Promise.resolve(JSON.parse(data)),
+          arrayBuffer: () => Promise.resolve(data),
+          text: () => Promise.resolve(data.toString('utf8')),
+          json: () => Promise.resolve(JSON.parse(data.toString('utf8'))),
         }
 
         if (!ok) {
-          const error = new Error(`${response.statusCode}: ${data}`)
+          const error = new Error(`${response.statusCode}: ${data.toString('utf8')}`)
           error.response = result
           reject(error)
           return

--- a/packages/react-storefront/test/fetch.test.js
+++ b/packages/react-storefront/test/fetch.test.js
@@ -29,6 +29,12 @@ describe('fetch', () => {
     expect(data).toHaveProperty('title');
   })
 
+  it('should respond with a buffer', async () => {
+    const data = await fetch('https://jsonplaceholder.typicode.com/posts/1')
+		  .then(res => res.arrayBuffer());
+    expect(JSON.parse(data.toString('utf8'))).toHaveProperty('title');
+  })
+
   it('should POST string data verbatim', async () => {
     const data = await fetch('https://jsonplaceholder.typicode.com/posts', {
 		    body: JSON.stringify({


### PR DESCRIPTION
I added support for res.arrayBuffer() to our fetch implementation.  This is a standard method from the fetch spec.  I also made it so that data is always downloaded into a buffer, and only decoded when you call res.json() or res.text().

https://moovweb.atlassian.net/browse/PRPL-1536