### PR TITLE
Skip video URLs in service worker to fix known Safari issue.

### DIFF
--- a/packages/react-storefront/service-worker/bootstrap.js
+++ b/packages/react-storefront/service-worker/bootstrap.js
@@ -289,9 +289,19 @@ function shouldServeHTMLFromCache(url, event) {
   return isAmp({ pathname: event.request.referrer }) || /\?source=pwa/.test(url.search)
 }
 
+/**
+ * Returns true of the request is for a video file
+ * @param {Object} context
+ * @return {Boolean}
+ */
+function isVideo(context) {
+  return context.url.pathname.match(/\.mp4$/)
+}
+
 const matchRuntimePath = (context) => {
   return isSecure(context) && /* non secure requests will fail */ 
-    !isStaticAsset(context) /* let precache routes handle those */
+    !isStaticAsset(context) && /* let precache routes handle those */
+    !isVideo(context) /* Safari has a known issue with service workers and videos: https://adactio.com/journal/14452 */
 }
 
 workbox.routing.registerRoute(matchRuntimePath, async (context) => {


### PR DESCRIPTION
Safari won't play MP4 videos if they are processed by the service worker.  This PR adds a rule to omit videos from the catch-all API route.

Some background on the issue:
https://adactio.com/journal/14452