### PR TITLE
Fix style passing in TabsRow.js

### DIFF
--- a/packages/react-storefront/src/TabsRow.js
+++ b/packages/react-storefront/src/TabsRow.js
@@ -177,7 +177,14 @@ export default class TabsRow extends Component {
             }
 
             if (tabRenderer) {
-              return tabRenderer(item, i)
+              const itemWithClasses = {
+                ...item,
+                classes: {
+                  root: classes.tab,
+                  selected: classes.selectedTab
+                }
+              }
+              return tabRenderer(itemWithClasses, i)
             } else {
               return (
                 <Tab


### PR DESCRIPTION
We should pass classes into `tabRenderer` too. 
Otherwise passed classes from NavBar doesn't work as expected.

How to reproduce:

Create `<NavTabs classes={ classes }/>`
Pass classes with `classes.tab = { fontSize: 1000 }`, as expected
Actual result: Standart NavBar
Expected result: NavBar with huge text