### PR TITLE
FilterButton: AMP update

### DIFF
--- a/packages/react-storefront/src/FilterButton.js
+++ b/packages/react-storefront/src/FilterButton.js
@@ -73,9 +73,11 @@ export default class FilterButton extends Component {
   constructor({ app }) {
     super()
 
+    const openFilter = app.location.search.indexOf('openFilter') !== -1
+
     this.state = {
-      open: app.location.search.indexOf('openFilter') !== -1, 
-      mountDrawer: false
+      open: openFilter, 
+      mountDrawer: openFilter
     }
   }
 
@@ -83,12 +85,16 @@ export default class FilterButton extends Component {
     const { classes, app, model, title, drawerProps, hideClearLink, clearLinkText, ...props } = this.props
     const { open, mountDrawer } = this.state
     const { clear, drawer, ...buttonClasses } = classes
+    const pwaPath = app.location.pathname.replace(/\.amp/, '')
+    const pwaSearch = app.location.search
+    const queryChar = pwaSearch ? '&' : '?'
+    const ampUrl = pwaPath + pwaSearch + queryChar + 'openFilter'
 
     return (
       <Fragment>
         <ActionButton 
           label={title}
-          href={ app.amp ? `${app.location.pathname.replace(/\.amp/, '')}?openFilter` : null }
+          href={ app.amp ? ampUrl : null }
           value={this.getFilterList()} 
           classes={buttonClasses}
           {...props} 

--- a/packages/react-storefront/src/FilterButton.js
+++ b/packages/react-storefront/src/FilterButton.js
@@ -86,7 +86,7 @@ export default class FilterButton extends Component {
     const { open, mountDrawer } = this.state
     const { clear, drawer, ...buttonClasses } = classes
     const pwaPath = app.location.pathname.replace(/\.amp/, '')
-    const pwaSearch = app.location.search
+    const pwaSearch = app.location.search || ''
     const queryChar = pwaSearch ? '&' : '?'
     const ampUrl = pwaPath + pwaSearch + queryChar + 'openFilter'
 


### PR DESCRIPTION
Venus uses a copied and somewhat altered version of this component. 

In that project these changes were needed to get it to switch from amp to pwa when query params already exist. 

It was also necessary to set both state.open and state.mountDrawer to true when the openFilter param is present otherwise the drawer doesn't mount.

These changes don't effect normal pwa when the openFilter param is not present.