### PR TITLE
Fix redirects and errors when page=0

### DIFF
--- a/packages/react-storefront/src/model/SearchResultsModelBase.js
+++ b/packages/react-storefront/src/model/SearchResultsModelBase.js
@@ -153,7 +153,7 @@ export default types
     },
     /**
      * Sets the filtersChanged field
-     * @param {Boolean} changed 
+     * @param {Boolean} changed
      */
     setFiltersChanged(changed) {
       self.filtersChanged = changed
@@ -169,7 +169,7 @@ export default types
     }),
     /**
      * Toggles a facet on or off.
-     * @param {FacetModelBase} facet 
+     * @param {FacetModelBase} facet
      */
     toggleFilter(facet) {
       const { code } = facet
@@ -180,26 +180,28 @@ export default types
       } else {
         self.filters.splice(index, 1)
       }
-      
       self.filtersChanged = true
     },
     showPage: async function(page) {
       self.page = page
       let { pathname, search } = window.location
       search += search.length ? '&': '?'
-      search += `page=${self.page}`
-      
+      if (page > 0) {
+        search += `page=${page}`
+      }
+
       try {
         self.loadingMore = page > 0
         const results = await fetch(self.getShowMoreURL(`${pathname}.json${search}`)).then(res => res.json())
         if (isAlive(self)) {
           self.addItems(results.items)
+          self.updateTotalCount(results.total)
         }
-      } catch (e) {
+      }
+      finally {
         if (isAlive(self)) {
           self.endLoadingMore()
         }
-        throw e
       }
     },
     /**
@@ -221,7 +223,7 @@ export default types
     },
     /**
      * Adds more items to the results
-     * @param {Array} items 
+     * @param {Array} items
      */
     addItems(items) {
       if (self.page === 0) {
@@ -230,7 +232,9 @@ export default types
       if (Array.isArray(items)) {
         self.items = [...self.items, ...items]
       }
-      self.endLoadingMore()
+    },
+    updateTotalCount(count){
+      self.total = count
     },
     /**
      * Toggles the layout


### PR DESCRIPTION
When filters are changed page query parameter is reseted to `page=0` which produces redirects to HTML pages and throws an error. This parameter should be avoided when it is `0`.
![default](https://user-images.githubusercontent.com/673144/49810696-6bb22d80-fd6a-11e8-86ff-48e568aade45.png)

Related to these issues https://github.com/moovweb-projects/annieselke/pull/443