### PR TITLE
Handle a query parameter to open filters

### DIFF
--- a/packages/react-storefront/src/FilterButton.js
+++ b/packages/react-storefront/src/FilterButton.js
@@ -75,7 +75,7 @@ export default class FilterButton extends Component {
 
     this.state = {
       open: app.location.search.indexOf('openFilter') !== -1, 
-      mountDrawer: false
+      mountDrawer: app.location.search.indexOf('openFilter') !== -1
     }
   }
 


### PR DESCRIPTION
**Expected:** filters should be automatically shown on page load when there is the query parameter in url `?openFilter`
**Actual:** The Drawer is opened but filters are hidden

http://localhost:8080/Sleepwear/Sleepwear-By-Category/All-Sleepwear/c/all-sleepwear?openFilter
<img width="416" alt="default" src="https://user-images.githubusercontent.com/673144/49814313-0d894880-fd72-11e8-9977-1bedb82a8bfa.png">

Related to this issue https://moovweb.atlassian.net/browse/ANE-655