### PR TITLE
Update filters facets on category data response

### DIFF
--- a/packages/react-storefront/src/model/SearchResultsModelBase.js
+++ b/packages/react-storefront/src/model/SearchResultsModelBase.js
@@ -193,6 +193,7 @@ export default types
         if (isAlive(self)) {
           self.addItems(results.items)
           self.setTotal(results.total)
+          self.setFacetGroups(results.facetGroups)
         }
       }
       finally {
@@ -237,6 +238,13 @@ export default types
      */
     setTotal(total){
       self.total = total
+    },
+    /**
+     * Updates goups of filters
+     * @param {Object} facetGroups 
+     */
+    setFacetGroups(facetGroups){
+      self.facetGroups = facetGroups
     },
     /**
      * Toggles the layout


### PR DESCRIPTION
**Important! This may negatively affect all projects**

This change adds filters updating on click on the button "View Results". When new filtered data is returned and displayed on the screen the filter facets are updated also. Some of filters may disappear because they may be not available. For example choosing "Black" color may hide "Solid" pattern because there are no Solid items of this color at all.