### PR TITLE
PRPL-1792 Fix analytics on IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
     "hooks": {
       "pre-commit": "yarn precommit"
     }
+  },
+  "dependencies": {
+    "lodash": "^4.17.5"
   }
 }

--- a/packages/react-storefront/package.json
+++ b/packages/react-storefront/package.json
@@ -38,6 +38,7 @@
     "react-svg-loader": "^2.1.0",
     "react-transition-group": "^2.5.0",
     "react-universal-component": "^2.9.0",
+    "lodash": "^4.17.5",
     "webpack": "^3.11.0",
     "webpack-flush-chunks": "^1.2.3"
   },
@@ -104,7 +105,6 @@
     "isomorphic-unfetch": "^2.0.0",
     "js-cookie": "^2.2.0",
     "jss": "^9.8.7",
-    "lodash.isfunction": "^3.0.9",
     "md5-file": "^4.0.0",
     "mst-middlewares": "^2.0.5",
     "open-browser-webpack-plugin": "^0.0.5",

--- a/packages/react-storefront/src/ImageSwitcher.js
+++ b/packages/react-storefront/src/ImageSwitcher.js
@@ -384,7 +384,7 @@ export default class ImageSwitcher extends Component {
         prevState.selectedIndex && 
         prevState.selectedIndex !== this.state.selectedIndex && 
         this.props.product) {
-      analytics.imageSwitched({ product: this.props.product, imageUrl: this.props.images[this.state.selectedIndex] })
+      analytics.fire('imageSwitched', { product: this.props.product, imageUrl: this.props.images[this.state.selectedIndex] })
     }
   }
 

--- a/packages/react-storefront/src/Track.js
+++ b/packages/react-storefront/src/Track.js
@@ -85,7 +85,7 @@ export default class Track extends Component {
     const { event, trigger, app, children, onSuccess, ampData, ...data } = this.props
 
     setImmediate(async () => {
-      await analytics[event](data)
+      await analytics.fire(event, data)
       onSuccess()
     })
   }

--- a/packages/react-storefront/src/analytics.js
+++ b/packages/react-storefront/src/analytics.js
@@ -81,7 +81,7 @@ export default new Proxy(
       if (method === 'fire') {
         return fire
       } else {
-        return fire.bind(window, method)
+        return fire.bind(null, method)
       }
     }
   }

--- a/packages/react-storefront/src/analytics.js
+++ b/packages/react-storefront/src/analytics.js
@@ -6,8 +6,8 @@
 let _targets = []
 
 /**
- * Configures the PWA to broadcast events to all specified targets.  Once configured, You can all any method on
- * the the default import from this module it will attempt to call a method of the same name on each target.  
+ * Configures the PWA to broadcast events to all specified targets.  Once configured, You can call any method on
+ * on all targets by calling `analytics.fire(method, ...params)`.  
  * 
  * Example:
  * 
@@ -26,7 +26,7 @@ let _targets = []
  * 
  * import analytics from 'react-storefront/analytics'
  * 
- * analytics.someEvent() // this will call the 'someEvent' method on all configured targets
+ * analytics.fire('someEvent', { foo: 'bar' }) // this will call the 'someEvent(data)' method on all configured targets and pass { foo: 'bar' } as the data argument.
  * 
  * @param {AnalyticsTarget[]} targets An array of targets to notify when analytics events occur
  * @return {AnalyticsProvider}
@@ -37,6 +37,20 @@ export function configureAnalytics(...targets) {
 
 export function getTargets() {
   return _targets
+}
+
+function fire(event, ...args) {
+  for (let target of _targets) {
+    const fn = target[event]
+
+    if (fn) {
+      fn.apply(target, args)
+    } else {
+      if (typeof event === 'string') {
+        console.warn(`${target.constructor.name} does not support ${event}`)
+      }
+    }
+  }
 }
 
 /**
@@ -59,22 +73,15 @@ export function getTargets() {
  */
 export default new Proxy(
   { 
-    setHistory: () => {} // polyfill for IE11 requires defined fields in Target argument
+    setHistory: () => {}, // polyfill for IE11 requires defined fields in Target argument
+    fire
   }, 
   {
     get: function (o, method) {
-      return function(...args) {
-        for (let target of _targets) {
-          const fn = target[method]
-
-          if (fn) {
-            fn.apply(target, args)
-          } else {
-            if (typeof method === 'string') {
-              console.warn(`${target.constructor.name} does not support ${method}`)
-            }
-          }
-        }
+      if (method === 'fire') {
+        return fire
+      } else {
+        return fire.bind(window, method)
       }
     }
   }

--- a/packages/react-storefront/src/router/Router.js
+++ b/packages/react-storefront/src/router/Router.js
@@ -3,7 +3,7 @@
  * Copyright © 2017-2018 Moov Corporation.  All rights reserved.
  */
 import Route from 'route-parser'
-import isFunction from 'lodash.isfunction'
+import isFunction from 'lodash/isfunction'
 import qs from 'qs'
 import merge from 'lodash/merge'
 import cloneDeep from 'lodash/cloneDeep'

--- a/packages/react-storefront/test/analytics.test.js
+++ b/packages/react-storefront/test/analytics.test.js
@@ -18,6 +18,18 @@ describe('AnalyticsProvider', () => {
     })
   })
 
+  it('supports fire(event, ...params)', () => {
+    const targets = [1,2,3].map(i => ({ testMethod: jest.fn() }))
+    
+    configureAnalytics(...targets)
+    const data = { search: { keywords: 'red shirt' } }
+    analytics.fire('testMethod', data)
+
+    targets.forEach(target => {
+      expect(target.testMethod).toHaveBeenCalledWith(data)
+    })
+  })
+
   it('displays a warning when a target does not support a method', () => {
     jest.spyOn(global.console, 'warn')
     const target = {}

--- a/packages/react-storefront/webpack/common.js
+++ b/packages/react-storefront/webpack/common.js
@@ -162,6 +162,7 @@ function createPlugins(root) {
 function createAliases(root) {
   return {
     "mobx": path.join(root, 'node_modules', 'mobx'),
+    "lodash": path.join(root, 'node_modules', 'lodash'),
     "react": path.join(root, 'node_modules', 'react'),
     "react-dom": path.join(root, 'node_modules', 'react-dom'),
     "react-helmet": path.join(root, 'node_modules', 'react-helmet'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7684,10 +7684,6 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
-lodash.isfunction@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"


### PR DESCRIPTION
This fixes analytics in IE11, which was not working due to IE's lack of native support for the proxies.  The proxy-polyfill we were using requires all properties to be declared ahead of time.  Due to the order in which apps initializes, knowing all built in and custom events ahead of time was not possible, so I've switched us away from using proxies and added a `fire` event.  The old proxy functionality is still supported to prevent regressions in apps that don't need to support IE (mobile only apps).