### PR TITLE
fix(amp): [PRPL-1968] Fix expand/collapse icons for AmpExpandableSection

### DIFF
--- a/packages/react-storefront/src/amp/AmpExpandableSection.js
+++ b/packages/react-storefront/src/amp/AmpExpandableSection.js
@@ -95,8 +95,8 @@ export default class AmpExpandableSection extends Component {
           <section className={classes.section} {...sectionAttributes}>
             <Typography variant="subtitle1" component="h3" className={classes.title}>
               {title}
-              <ExpandIcon className={classnames(classes.toggle, classes.collapse)}/>
-              <CollapseIcon className={classnames(classes.toggle, classes.expand)}/>
+              <ExpandIcon className={classnames(classes.toggle, classes.expand)}/>
+              <CollapseIcon className={classnames(classes.toggle, classes.collapse)}/>
             </Typography>
             <div className={classes.body}>
               { children }


### PR DESCRIPTION
Fixes [PRPL-1968](https://moovweb.atlassian.net/browse/PRPL-1968).

Before:
![screen shot 2019-02-08 at 12 27 38 pm](https://user-images.githubusercontent.com/2205550/52496198-bac8e300-2ba0-11e9-8558-4d8269214a4b.png)

After:
![screen shot 2019-02-08 at 12 54 27 pm](https://user-images.githubusercontent.com/2205550/52496202-bd2b3d00-2ba0-11e9-92e0-c0822ead9ec1.png)
