### PR TITLE
remove proxy-polyfill entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ npm link babel-plugin-react-storefront
 
 ## Changelog
 
+### 5.9.0
+
+* Removed proxy-polyfill, which was causing errors when using analytics in IE11. If you plan to support IE11 and use analytics, you must call `analytics.fire('eventName', data)` instead of the proxied methods like `analytics.eventName(data)`.
+
 ### 5.8.2
 
 * Fixed a bug causing the Filter component's apply button to be hidden on iOS.

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "5.8.2",
+  "version": "5.8.3-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/react-storefront/package.json
+++ b/packages/react-storefront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-storefront",
-  "version": "5.8.2",
+  "version": "5.8.3-alpha.0",
   "description": "Build and deploy e-commerce progressive web apps in record time.",
   "browser": "src",
   "module": "./index.js",

--- a/packages/react-storefront/src/analytics.js
+++ b/packages/react-storefront/src/analytics.js
@@ -71,12 +71,11 @@ function fire(event, ...args) {
  *  )
  * 
  */
-export default new Proxy(
-  { 
-    setHistory: () => {}, // polyfill for IE11 requires defined fields in Target argument
-    fire
-  }, 
-  {
+
+let analytics = { fire }
+
+if (typeof Proxy !== 'undefined') {
+  analytics = new Proxy({ fire }, {
     get: function (o, method) {
       if (method === 'fire') {
         return fire
@@ -84,5 +83,7 @@ export default new Proxy(
         return fire.bind(null, method)
       }
     }
-  }
-)
+  })
+}
+
+export default analytics

--- a/packages/react-storefront/src/launchClient.js
+++ b/packages/react-storefront/src/launchClient.js
@@ -2,7 +2,6 @@
  * @license
  * Copyright © 2017-2018 Moov Corporation.  All rights reserved.
  */
-import 'proxy-polyfill' // needed for IE9-11
 import React from 'react'
 import { hydrate } from './renderers'
 import { connectReduxDevtools } from "mst-middlewares"


### PR DESCRIPTION
The google proxy-polyfill was more trouble than it was worth.  It actually throws an error in IE11 during initialization.  Since we have analytics.fire now, this isn't really needed.  The old proxied methods will continue to work in modern browsers, but if you need IE11 support, you won't be able to use them.