### PR TITLE
Added the ability to split and normalize the server cache for routes …

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ yarn release
 
 ## Changelog
 
+### 6.34.0
+
+- Added the ability to split and normalize the server cache for routes using the `cache()` handler's new `server.key` property and `react-storefront/router/createCustomCacheKey`.
+
 ### 6.33.1
 
 - Fixed linking to JS assets introduced in 6.33.0

--- a/packages/react-storefront/src/router/Router.js
+++ b/packages/react-storefront/src/router/Router.js
@@ -12,6 +12,7 @@ import ClientContext from './ClientContext'
 import EventEmitter from 'eventemitter3'
 import powerLinkHandler from './powerLinkHandler'
 import fromServer from './fromServer'
+import RegexpVisitor from 'route-parser/lib/route/visitors/regexp'
 
 /**
  * Provides routing for MUR-based applications and PWAs.  This class is inspired by express and uses https://github.com/rcs/route-parser,
@@ -579,5 +580,29 @@ export default class Router extends EventEmitter {
     )
 
     history.replace(`${history.location.pathname}?${nextParams}`)
+  }
+
+  createEdgeCacheConfiguration() {
+    const customCacheKeys = []
+
+    for (let route of this.routes) {
+      const cache = route.handlers.find(handler => handler.type === 'cache')
+      if (!cache || !cache.server || !cache.server.key) continue
+      customCacheKeys.push({
+        path_regex: this.routeToRegex(route),
+        ...cache.server.key.toJSON()
+      })
+    }
+
+    return customCacheKeys
+  }
+
+  /**
+   * Gets the regular expression for the specified route
+   * @private
+   * @param {Object} route
+   */
+  routeToRegex(route) {
+    return RegexpVisitor.visit(route.path.ast).re
   }
 }

--- a/packages/react-storefront/src/router/cache.js
+++ b/packages/react-storefront/src/router/cache.js
@@ -15,12 +15,14 @@ import { SURROGATE_KEY } from './headers'
  *   cache({
  *     server: {
  *       maxAgeSeconds: 300 // cache for 5 minutes on the server,
- *       key: (request, defaults) => ({ // cache result separately for mobile and desktop user agents
- *         ...defaults,
- *         mobile: ['iOS', 'Android'].includes(
- *           new UAParser(request.headers['user-agent']).getOS().name
- *         )
- *       })
+ *       key: createCustomCacheKey() // split cache by user-agent header, currency, and location (with bucketing), and exclude the ?uid search parameter from the cache key
+ *         .addHeader('user-agent')
+ *         .removeQueryParameter('uid')
+ *         .addCookie('currency')
+ *         .addCookie('location', cookie => {
+ *           cookie.partition('na').byPattern('us|ca')
+ *           cookie.partition('eur').byPattern('de|fr|ee')
+ *         })
  *     },
  *     client: true // cache in the service worker based on the settings passed to router.configureClientCache()
  *   })
@@ -31,10 +33,12 @@ import { SURROGATE_KEY } from './headers'
  *
  * @param {Object} options
  * @param {Number} options.server
- * @param {Number} options.server.maxAgeSeconds The number of seconds the result should be cached on the server.  The maxAgeSeconds key is required when specifying a server config.
- * @param {Function} options.server.key A function to compute a custom cache key for server-side caching.  The function is
- *  passed the request object and a defaults object containing the key/value pairs that make up the default cache key.  This function is optional when specifying a server config.
- * @param {Boolean} options.client Set to true to cache on the client based on the configuration defined by router.configureClientCache(). Defaults to false.
+ * @param {Number} options.server.maxAgeSeconds The number of seconds the result should be cached on
+ *  the server.  The maxAgeSeconds key is required when specifying a server config.
+ * @param {Object} options.server.key A custom cache key to override the default caching behavior.  Use this to split the cache by
+ *  headers and cookies, and/or normalize the cache by removing specific query parameters.
+ * @param {Boolean} options.client Set to true to cache on the client based on the configuration defined
+ *  by router.configureClientCache(). Defaults to false.
  * @return {Object}
  */
 export default function cache({ server, client }) {

--- a/packages/react-storefront/src/router/createCustomCacheKey.js
+++ b/packages/react-storefront/src/router/createCustomCacheKey.js
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright © 2017-2019 Moov Corporation.  All rights reserved.
+ */
+/**
+ * @private
+ */
+class CustomCacheKey {
+  headers = []
+  removeQueryParameters = []
+  cookies = {}
+
+  addHeader(name) {
+    this.headers.push(name)
+    return this
+  }
+
+  removeQueryParameter(name) {
+    this.removeQueryParameters.push(name)
+    return this
+  }
+
+  addCookie(name, createPartitions) {
+    const cookie = new CookieConfig()
+
+    if (typeof createPartitions === 'function') {
+      createPartitions(cookie)
+    }
+
+    this.cookies[name] = cookie.toJSON()
+
+    return this
+  }
+
+  toJSON() {
+    return {
+      add_headers: this.headers,
+      remove_query_parameters: this.removeQueryParameters,
+      add_cookies: this.cookies
+    }
+  }
+}
+
+/**
+ * @private
+ */
+class CookieConfig {
+  partitions = []
+  name = null
+
+  partition(name) {
+    const partition = new PartitionConfig(name)
+    this.partitions.push(partition)
+    return partition
+  }
+
+  toJSON() {
+    if (this.partitions.length === 0) {
+      return null
+    } else {
+      return this.partitions.map(p => p.toJSON())
+    }
+  }
+}
+
+/**
+ * @private
+ */
+class PartitionConfig {
+  pattern = null
+  name = null
+
+  constructor(name) {
+    this.name = name
+  }
+
+  byPattern(pattern) {
+    this.pattern = pattern
+  }
+
+  toJSON() {
+    return {
+      partition: this.name,
+      partitioning_regex: this.pattern
+    }
+  }
+}
+
+/**
+ * Returns a DSL for creating custom server cache keys based on cookies, query parameters, and
+ * request headers.
+ *
+ * example:
+ *
+ * ```js
+ *  new Router()
+ *    .get('/s/:id',
+ *      cache({
+ *        server: {
+ *          key: createCustomCacheKey()
+ *            .addHeader('user-agent')
+ *            .removeQueryParameter('uid')
+ *            .addCookie('location', cookie => {
+ *              cookie.partition('na').byPattern('us|ca')
+ *              cookie.partition('eur').byPattern('de|fr|ee')
+ *            })
+ *        }
+ *      })
+ *    )
+ * ```
+ */
+export default function createCustomCacheKey() {
+  return new CustomCacheKey()
+}

--- a/packages/react-storefront/test/router/Router.test.js
+++ b/packages/react-storefront/test/router/Router.test.js
@@ -10,6 +10,7 @@ import * as serviceWorker from '../../src/router/serviceWorker'
 import { createMemoryHistory } from 'history'
 import qs from 'qs'
 import Response from '../../../react-storefront-moov-xdn/src/Response'
+import createCustomCacheKey from '../../src/router/createCustomCacheKey'
 
 describe('Router:Node', function() {
   let router, runAll, response
@@ -827,6 +828,72 @@ describe('Router:Node', function() {
     it('should return false if the route has a cache handler with client: false', () => {
       router.get('/cart')
       expect(router.willCacheOnClient({ path: '/cart.json' })).toBe(false)
+    })
+  })
+
+  describe('createEdgeCacheConfiguration', () => {
+    let key, cacheHandler
+
+    beforeEach(() => {
+      key = createCustomCacheKey()
+        .addHeader('user-agent')
+        .addHeader('host')
+        .removeQueryParameter('uid')
+        .removeQueryParameter('gclid')
+        .addCookie('currency')
+        .addCookie('location', cookie => {
+          cookie.partition('na').byPattern('us|ca')
+          cookie.partition('eur').byPattern('de|fr|ee')
+        })
+      cacheHandler = cache({
+        server: {
+          maxAgeSeconds: 300,
+          key
+        }
+      })
+    })
+
+    it('should return generate custom cache keys for outer edge manager', () => {
+      const router = new Router().get('/', cacheHandler).get('/p/:id', cacheHandler)
+
+      const customKey = {
+        add_cookies: {
+          currency: null,
+          location: [
+            { partition: 'na', partitioning_regex: 'us|ca' },
+            { partition: 'eur', partitioning_regex: 'de|fr|ee' }
+          ]
+        },
+        add_headers: ['user-agent', 'host'],
+        remove_query_parameters: ['uid', 'gclid']
+      }
+
+      expect(router.createEdgeCacheConfiguration()).toEqual([
+        {
+          path_regex: /^\/\.json(?=\?|$)/,
+          ...customKey
+        },
+        {
+          path_regex: /^\/\.amp(?=\?|$)/,
+          ...customKey
+        },
+        {
+          path_regex: /^\/(?=\?|$)/,
+          ...customKey
+        },
+        {
+          path_regex: /^\/p\/([^\/\?]+)\.json(?=\?|$)/,
+          ...customKey
+        },
+        {
+          path_regex: /^\/p\/([^\/\?]+)\.amp(?=\?|$)/,
+          ...customKey
+        },
+        {
+          path_regex: /^\/p\/([^\/\?]+)(?=\?|$)/,
+          ...customKey
+        }
+      ])
     })
   })
 

--- a/packages/react-storefront/test/router/createCustomCacheKey.test.js
+++ b/packages/react-storefront/test/router/createCustomCacheKey.test.js
@@ -1,0 +1,28 @@
+import createCustomCacheKey from '../../src/router/createCustomCacheKey'
+
+describe('createCustomCacheKey', () => {
+  it('should support toJSON', () => {
+    const key = createCustomCacheKey()
+      .addHeader('user-agent')
+      .addHeader('host')
+      .removeQueryParameter('uid')
+      .removeQueryParameter('gclid')
+      .addCookie('currency')
+      .addCookie('location', cookie => {
+        cookie.partition('na').byPattern('us|ca')
+        cookie.partition('eur').byPattern('de|fr|ee')
+      })
+
+    expect(key.toJSON()).toEqual({
+      add_headers: ['user-agent', 'host'],
+      remove_query_parameters: ['uid', 'gclid'],
+      add_cookies: {
+        currency: null,
+        location: [
+          { partition: 'na', partitioning_regex: 'us|ca' },
+          { partition: 'eur', partitioning_regex: 'de|fr|ee' }
+        ]
+      }
+    })
+  })
+})


### PR DESCRIPTION
…using the `cache()` handler's new `server.key` property and `react-storefront/router/createCustomCacheKey`.