### PR TITLE
ExpandableSection should always have `expanded` prop

### DIFF
--- a/packages/react-storefront/src/Filter.js
+++ b/packages/react-storefront/src/Filter.js
@@ -200,7 +200,7 @@ export default class Filter extends Component {
         key={key}
         title={group.name}
         caption={caption}
-        expanded={expanded[group.name]}
+        expanded={expanded[group.name] || false}
         onChange={(e, expanded) =>
           this.setState({ expanded: { ...this.state.expanded, [group.name]: expanded } })
         }


### PR DESCRIPTION
If prop is not defined or undefined then <ExpansionPanel> switches to "isControlled" mode and doesn't show <ExpansionPanelDetails> even we pass `expanded=true` prop
https://github.com/mui-org/material-ui/blob/2df26ad7b0bef76f9e22d4ec95ccb09b118e25bc/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js#L97

![screencast 2019-08-29 15-08-51](https://user-images.githubusercontent.com/992525/63939617-556f0d80-ca70-11e9-9425-3c20c3990a1f.gif)
