### PR TITLE
Fix issue where personalization data would load when the product page was hidden.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ yarn release
 
 ## Changelog
 
+### 6.64.0
+
+- `withPersonalization` will no longer fire the supplied callback unless the parent page component is visible.
+
 ### 6.63.0
 
 - Optimized css minification to reduce request handling time.

--- a/packages/react-storefront/src/Pages.js
+++ b/packages/react-storefront/src/Pages.js
@@ -13,6 +13,8 @@ import Row from './Row'
 import red from '@material-ui/core/colors/red'
 import { waitForServiceWorkerController } from './router/serviceWorker'
 
+export const PageContext = React.createContext()
+
 export const styles = theme => ({
   root: {
     position: 'relative',
@@ -158,13 +160,14 @@ export default class Pages extends Component {
       const entry = this.cache[page]
 
       elements.push(
-        <div
-          key={page}
-          data-page={page}
-          style={{ display: page === app.page && !loading ? 'block' : 'none' }}
-        >
-          {entry.element}
-        </div>
+        <PageContext.Provider value={page} key={page}>
+          <div
+            data-page={page}
+            style={{ display: page === app.page && !loading ? 'block' : 'none' }}
+          >
+            {entry.element}
+          </div>
+        </PageContext.Provider>
       )
     }
 

--- a/packages/react-storefront/src/personal/usePersonalization.js
+++ b/packages/react-storefront/src/personal/usePersonalization.js
@@ -2,9 +2,10 @@
  * @license
  * Copyright © 2017-2019 Moov Corporation.  All rights reserved.
  */
-import { useEffect, useContext } from 'react'
+import { useEffect, useContext, useRef } from 'react'
 import AppContext from '../AppContext'
 import { reaction } from 'mobx'
+import { PageContext } from '../Pages'
 
 /**
  * A hook for fetching late-loaded personalized data.  This hook automatically
@@ -25,14 +26,15 @@ import { reaction } from 'mobx'
  */
 export default function usePersonalization(branch) {
   const { app } = useContext(AppContext)
+  const pageContext = useContext(PageContext)
+  const id = useRef(null)
 
-  const loadPersonalization = ready => {
-    const model = branch(app)
-
+  const loadPersonalization = async ({ loading, page, model }) => {
     if (model == null) {
       return
     } else if (model.loadPersonalization) {
-      if (ready) {
+      if (pageContext === page && !loading) {
+        id.current = model.id
         model.loadPersonalization()
       }
     } else {
@@ -42,7 +44,11 @@ export default function usePersonalization(branch) {
     }
   }
 
-  const shouldFetchPersonalization = () => !app.loading && branch(app)
+  const shouldFetchPersonalization = () => ({
+    loading: app.loading,
+    page: app.page,
+    model: branch(app)
+  })
 
   useEffect(() => {
     // check if we should load personalization data immediately as is the case if

--- a/packages/react-storefront/test/personal/usePersonalization.test.js
+++ b/packages/react-storefront/test/personal/usePersonalization.test.js
@@ -32,9 +32,11 @@ describe('usePersonalization', () => {
       return null
     }
 
-    Test = ({ app }) => (
+    Test = ({ app, page }) => (
       <AppContext.Provider value={{ app }}>
-        <Comp />
+        <PageContext.Provider value={page || app.page}>
+          <Comp />
+        </PageContext.Provider>
       </AppContext.Provider>
     )
   })
@@ -68,6 +70,21 @@ describe('usePersonalization', () => {
     expect(loadPersonalization).not.toHaveBeenCalled()
   })
 
+  it('should not fire unless the page context matches the current page', () => {
+    const app = AppModel.create({ loading: true, page: 'Product' })
+
+    mount(<Test app={app} page="Subcategory" />)
+
+    app.applyState({
+      loading: false,
+      product: {
+        id: '1'
+      }
+    })
+
+    expect(loadPersonalization).not.toHaveBeenCalled()
+  })
+
   it('should not fire if another branch changes', () => {
     const app = AppModel.create({ loading: true, page: 'Product' })
 
@@ -83,7 +100,3 @@ describe('usePersonalization', () => {
     expect(loadPersonalization).not.toHaveBeenCalled()
   })
 })
-
-export default client => async ({ error, app, history }) => {
-  // ...
-}

--- a/packages/react-storefront/test/personal/withPersonalization.test.js
+++ b/packages/react-storefront/test/personal/withPersonalization.test.js
@@ -2,10 +2,10 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { types } from 'mobx-state-tree'
 import AppContext from '../../src/AppContext'
-import { PageContext } from '../../src/Pages'
 import withPersonalization from '../../src/personal/withPersonalization'
 import AppModelBase from '../../src/model/AppModelBase'
 import ProductModelBase from '../../src/model/ProductModelBase'
+import { PageContext } from '../../src/Pages'
 
 describe('withPersonalization', () => {
   let AppModel, ProductModel, loadPersonalization, Test
@@ -31,7 +31,9 @@ describe('withPersonalization', () => {
 
     Test = ({ app }) => (
       <AppContext.Provider value={{ app }}>
-        <Comp />
+        <PageContext.Provider value="Product">
+          <Comp />
+        </PageContext.Provider>
       </AppContext.Provider>
     )
   })


### PR DESCRIPTION
- withPersonalization will no longer fire the supplied callback unless the parent page component is visible.
- Adds a PageContext that any component can consume to determine if it's within the currently displayed page.