### PR TITLE
You can now use the stale-while-revalidate caching strategy at the ed…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ yarn release
 
 ## Changelog
 
+### 6.66.0
+
+- You can now use the stale-while-revalidate caching strategy at the edge by specifying `staleWhileRevalidateSeconds`:
+
+```js
+router.get(
+  '/p/:id',
+  cache({
+    edge: {
+      staleWhileRevalidateSeconds: 24 * 60 * 60
+    }
+  })
+)
+```
+
 ### 6.65.1
 
 - You can now use `fromOrigin` in local development. In local development `fromOrigin` simply uses `proxyUpstream()` with no arguments.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ yarn release
 
 ## Changelog
 
-### 6.66.0
+### 6.71.0
 
 - You can now use the stale-while-revalidate caching strategy at the edge by specifying `staleWhileRevalidateSeconds`:
 

--- a/packages/react-storefront-middleware/index.js
+++ b/packages/react-storefront-middleware/index.js
@@ -13,7 +13,7 @@ module.exports = function(server) {
 
     Object.assign(res, {
       relayUpstreamCookies: Function.prototype,
-      cacheOnServer: Function.prototype
+      cacheAtEdge: Function.prototype
     })
 
     // shim get, which is provided on the moovweb platform

--- a/packages/react-storefront-moov-xdn/src/Response.js
+++ b/packages/react-storefront-moov-xdn/src/Response.js
@@ -180,10 +180,8 @@ export default class Response {
    * @return {Response} this
    */
   cacheOnServer({ maxAgeSeconds, staleWhileRevalidateSeconds }) {
-    if (maxAgeSeconds == null && staleWhileRevalidateSeconds == null)
-      throw new Error(
-        'You must specify either maxAgeSeconds or staleWhileRevalidateSeconds when calling response.cacheOnServer.'
-      )
+    if (maxAgeSeconds == null)
+      throw new Error('You must specify maxAgeSeconds when calling response.cacheOnServer.')
 
     this.cache = {
       serverMaxAge: maxAgeSeconds,

--- a/packages/react-storefront-moov-xdn/src/Response.js
+++ b/packages/react-storefront-moov-xdn/src/Response.js
@@ -55,7 +55,8 @@ export default class Response {
    */
   cache = {
     browserMaxAge: 0,
-    serverMaxAge: 0
+    serverMaxAge: 0,
+    serverStaleWhileRevalidate: 0
   }
 
   /**
@@ -175,14 +176,18 @@ export default class Response {
   /**
    * Caches the response on the server
    * @param {Number} maxAgeSeconds The time the entry should live in the cache in seconds
+   * @param {Number} staleWhileRevalidateSeconds The time the entry should live before being refreshed in seconds.
    * @return {Response} this
    */
-  cacheOnServer(maxAgeSeconds) {
-    if (maxAgeSeconds == null)
-      throw new Error('maxAgeSeconds cannot be null in call to response.cacheOnServer')
+  cacheOnServer({ maxAgeSeconds, staleWhileRevalidateSeconds }) {
+    if (maxAgeSeconds == null && staleWhileRevalidateSeconds == null)
+      throw new Error(
+        'You must specify either maxAgeSeconds or staleWhileRevalidateSeconds when calling response.cacheOnServer.'
+      )
 
     this.cache = {
       serverMaxAge: maxAgeSeconds,
+      serverStaleWhileRevalidate: staleWhileRevalidateSeconds,
       browserMaxAge: 0
     }
 

--- a/packages/react-storefront-moov-xdn/src/Response.js
+++ b/packages/react-storefront-moov-xdn/src/Response.js
@@ -174,12 +174,21 @@ export default class Response {
   }
 
   /**
+   * The same as cacheAtEdge.  This method is deprecated but was left in for backwards
+   * compatbility with earlier versions of React Storefront
+   * @return {Response} this
+   */
+  cacheOnServer(options) {
+    return this.cacheAtEdge(options)
+  }
+
+  /**
    * Caches the response on the server
    * @param {Number} maxAgeSeconds The time the entry should live in the cache in seconds
    * @param {Number} staleWhileRevalidateSeconds The time the entry should live before being refreshed in seconds.
    * @return {Response} this
    */
-  cacheOnServer({ maxAgeSeconds, staleWhileRevalidateSeconds }) {
+  cacheAtEdge({ maxAgeSeconds, staleWhileRevalidateSeconds }) {
     if (maxAgeSeconds == null)
       throw new Error('You must specify maxAgeSeconds when calling response.cacheOnServer.')
 

--- a/packages/react-storefront-moov-xdn/src/cache.js
+++ b/packages/react-storefront-moov-xdn/src/cache.js
@@ -6,10 +6,11 @@
 /**
  * Sets the correct response headers to configure browser and server caching
  * @param {Object} options
- * @param {Number} options.serverMaxAge The TTL for the edge caches.  Set to 0 to send a no-cache.  Omit to send no value for the client.
+ * @param {Number} options.serverMaxAge The max age in seconds for edge caches.
+ * @param {Number} options.serverStaleWhileRevalidate The time in seconds before revalidation for edge caches.
  * @param {Number} options.browserMaxAge The TTL for the browser's cache
  */
-export function cache({ serverMaxAge, browserMaxAge }) {
+export function cache({ serverMaxAge, serverStaleWhileRevalidate, browserMaxAge }) {
   const cacheControl = []
 
   if (browserMaxAge === 0) {
@@ -18,13 +19,23 @@ export function cache({ serverMaxAge, browserMaxAge }) {
     cacheControl.push(`max-age=${browserMaxAge}`)
   }
 
+  const serverHeaders = []
+
   if (serverMaxAge) {
+    serverHeaders.push(`max-age=${serverMaxAge}`)
+  }
+
+  if (serverStaleWhileRevalidate) {
+    serverHeaders.push(`stale-while-revalidate=${serverStaleWhileRevalidate}`)
+  }
+
+  if (serverHeaders.length) {
     // remove these headers so varnish caching works correctly
     headers.removeAllHeaders('Age')
     headers.removeAllHeaders('Via')
     headers.removeAllHeaders('Expires')
     headers.header('X-Moov-Cache', 'true')
-    cacheControl.push(`s-maxage=${serverMaxAge}`)
+    headers.header('x-moov-cache-control', serverHeaders.join(', '))
   }
 
   if (cacheControl.length) {

--- a/packages/react-storefront-moov-xdn/src/cache.js
+++ b/packages/react-storefront-moov-xdn/src/cache.js
@@ -7,7 +7,7 @@
  * Sets the correct response headers to configure browser and server caching
  * @param {Object} options
  * @param {Number} options.serverMaxAge The max age in seconds for edge caches.
- * @param {Number} options.serverStaleWhileRevalidate The time in seconds before revalidation for edge caches.
+ * @param {Number} options.serverStaleWhileRevalidate The number seconds beyond `serverMaxAge` when a stale response will be served from the cache.
  * @param {Number} options.browserMaxAge The TTL for the browser's cache
  */
 export function cache({ serverMaxAge, serverStaleWhileRevalidate, browserMaxAge }) {

--- a/packages/react-storefront-moov-xdn/src/redirect.js
+++ b/packages/react-storefront-moov-xdn/src/redirect.js
@@ -11,11 +11,7 @@ import { cache } from './cache'
 function isAmpPost() {
   const { referer } = env
 
-  return (
-    referer && 
-    referer.split('?')[0].endsWith('.amp') &&
-    env.method.toLowerCase() === 'post'
-  )
+  return referer && referer.split('?')[0].endsWith('.amp') && env.method.toLowerCase() === 'post'
 }
 
 /**
@@ -23,7 +19,7 @@ function isAmpPost() {
  * @param {String} url The destination url.  Can be relative or absolute.
  * @param {Number} statusCode The status code to send.  Defaults to 301
  */
-export function redirectTo(url, statusCode=301) {
+export function redirectTo(url, statusCode = 301) {
   const protocol = (env.referer && env.referer.split(/:/)[0]) || 'https'
 
   if (!url.match(/https?:\/\//)) {
@@ -31,16 +27,19 @@ export function redirectTo(url, statusCode=301) {
   }
 
   if (isAmpPost()) {
-    headers.addHeader("amp-redirect-to", url)
-    headers.addHeader("access-control-expose-headers", "AMP-Access-Control-Allow-Source-Origin,AMP-Redirect-To")
-    headers.addHeader("amp-access-control-allow-source-origin", `${protocol}://${env.host}`)
+    headers.addHeader('amp-redirect-to', url)
+    headers.addHeader(
+      'access-control-expose-headers',
+      'AMP-Access-Control-Allow-Source-Origin,AMP-Redirect-To'
+    )
+    headers.addHeader('amp-access-control-allow-source-origin', `${protocol}://${env.host}`)
   } else {
-    headers.removeAllHeaders("Location")
-    headers.addHeader("Location", url)
+    headers.removeAllHeaders('Location')
+    headers.addHeader('Location', url)
     headers.statusCode = statusCode
   }
 
-  cache({ serverMaxAge: 0, browserMaxAge: 0 })
+  cache({ serverMaxAge: 0, serverStaleWhileRevalidate: 0, browserMaxAge: 0 })
 }
 
 /**

--- a/packages/react-storefront-moov-xdn/src/responseHeaderTransform.js
+++ b/packages/react-storefront-moov-xdn/src/responseHeaderTransform.js
@@ -84,6 +84,7 @@ export default function responseHeaderTransform({
   // never cache responses with an error status or temporary redirect
   if (headers.statusCode >= 400 || headers.statusCode === 302) {
     headers.removeAllHeaders('cache-control')
+    headers.removeAllHeaders('x-moov-cache-control')
   }
 
   // The browser should never cache rejected prefetches, otherwise it has the effect of

--- a/packages/react-storefront-moov-xdn/test/Response.test.js
+++ b/packages/react-storefront-moov-xdn/test/Response.test.js
@@ -141,7 +141,9 @@ describe('Response', () => {
 
     it('should return the response', () => {
       expect(response.cacheOnServer({ maxAgeSeconds: 100 })).toBe(response)
-      expect(response.cacheOnServer({ staleWhileRevalidateSeconds: 100 })).toBe(response)
+      expect(response.cacheOnServer({ maxAgeSeconds: 100, staleWhileRevalidateSeconds: 100 })).toBe(
+        response
+      )
     })
 
     it('should throw an Error if no parameter is provided', () => {

--- a/packages/react-storefront-moov-xdn/test/Response.test.js
+++ b/packages/react-storefront-moov-xdn/test/Response.test.js
@@ -33,7 +33,8 @@ describe('Response', () => {
         cookies: [],
         cache: {
           browserMaxAge: 0,
-          serverMaxAge: 0
+          serverMaxAge: 0,
+          serverStaleWhileRevalidate: 0
         },
         headers: {
           'x-moov-test': 'test'
@@ -61,7 +62,8 @@ describe('Response', () => {
         ],
         cache: {
           browserMaxAge: 0,
-          serverMaxAge: 0
+          serverMaxAge: 0,
+          serverStaleWhileRevalidate: 0
         }
       })
     })
@@ -83,7 +85,8 @@ describe('Response', () => {
         headers: {},
         cache: {
           browserMaxAge: 0,
-          serverMaxAge: 0
+          serverMaxAge: 0,
+          serverStaleWhileRevalidate: 0
         }
       })
     })
@@ -110,17 +113,35 @@ describe('Response', () => {
   })
 
   describe('cacheOnServer', () => {
-    it('should set the cache-control header', () => {
-      response.cacheOnServer(100)
-      expect(response.cache).toEqual({ browserMaxAge: 0, serverMaxAge: 100 })
+    it('should set the maxAgeSeconds', () => {
+      response.cacheOnServer({ maxAgeSeconds: 100, staleWhileRevalidateSeconds: 0 })
+      expect(response.cache).toEqual({
+        browserMaxAge: 0,
+        serverMaxAge: 100,
+        serverStaleWhileRevalidate: 0
+      })
+    })
+
+    it('should set staleWhileRevalidateSeconds', () => {
+      response.cacheOnServer({ staleWhileRevalidateSeconds: 100, maxAgeSeconds: 0 })
+      expect(response.cache).toEqual({
+        browserMaxAge: 0,
+        serverMaxAge: 0,
+        serverStaleWhileRevalidate: 100
+      })
     })
 
     it('should set the cache-control header to no-store, no-cache, maxage=0 by default', () => {
-      expect(response.cache).toEqual({ browserMaxAge: 0, serverMaxAge: 0 })
+      expect(response.cache).toEqual({
+        browserMaxAge: 0,
+        serverMaxAge: 0,
+        serverStaleWhileRevalidate: 0
+      })
     })
 
     it('should return the response', () => {
-      expect(response.cacheOnServer(100)).toBe(response)
+      expect(response.cacheOnServer({ maxAgeSeconds: 100 })).toBe(response)
+      expect(response.cacheOnServer({ staleWhileRevalidateSeconds: 100 })).toBe(response)
     })
 
     it('should throw an Error if no parameter is provided', () => {

--- a/packages/react-storefront-moov-xdn/test/Response.test.js
+++ b/packages/react-storefront-moov-xdn/test/Response.test.js
@@ -112,9 +112,9 @@ describe('Response', () => {
     })
   })
 
-  describe('cacheOnServer', () => {
+  describe('cacheAtEdge', () => {
     it('should set the maxAgeSeconds', () => {
-      response.cacheOnServer({ maxAgeSeconds: 100, staleWhileRevalidateSeconds: 0 })
+      response.cacheAtEdge({ maxAgeSeconds: 100, staleWhileRevalidateSeconds: 0 })
       expect(response.cache).toEqual({
         browserMaxAge: 0,
         serverMaxAge: 100,
@@ -123,7 +123,7 @@ describe('Response', () => {
     })
 
     it('should set staleWhileRevalidateSeconds', () => {
-      response.cacheOnServer({ staleWhileRevalidateSeconds: 100, maxAgeSeconds: 0 })
+      response.cacheAtEdge({ staleWhileRevalidateSeconds: 100, maxAgeSeconds: 0 })
       expect(response.cache).toEqual({
         browserMaxAge: 0,
         serverMaxAge: 0,
@@ -140,14 +140,14 @@ describe('Response', () => {
     })
 
     it('should return the response', () => {
-      expect(response.cacheOnServer({ maxAgeSeconds: 100 })).toBe(response)
-      expect(response.cacheOnServer({ maxAgeSeconds: 100, staleWhileRevalidateSeconds: 100 })).toBe(
+      expect(response.cacheAtEdge({ maxAgeSeconds: 100 })).toBe(response)
+      expect(response.cacheAtEdge({ maxAgeSeconds: 100, staleWhileRevalidateSeconds: 100 })).toBe(
         response
       )
     })
 
     it('should throw an Error if no parameter is provided', () => {
-      expect(() => response.cacheOnServer()).toThrow()
+      expect(() => response.cacheAtEdge()).toThrow()
     })
   })
 

--- a/packages/react-storefront-moov-xdn/test/cache.test.js
+++ b/packages/react-storefront-moov-xdn/test/cache.test.js
@@ -30,9 +30,25 @@ describe('cache', () => {
     expect(global.headers.header).not.toHaveBeenCalled()
   })
 
-  it('should send s-maxage when serverMaxAge is greater than 0', () => {
+  it('should send x-moov-cache-control with max-age when serverMaxAge is greater than 0', () => {
     cache({ serverMaxAge: 300 })
-    expect(global.headers.header).toHaveBeenCalledWith('Cache-Control', 's-maxage=300')
+    expect(global.headers.header).toHaveBeenCalledWith('x-moov-cache-control', 'max-age=300')
+  })
+
+  it('should send x-moov-cache-control with stale-while-revalidate when serverMaxAge is greater than 0', () => {
+    cache({ serverStaleWhileRevalidate: 300 })
+    expect(global.headers.header).toHaveBeenCalledWith(
+      'x-moov-cache-control',
+      'stale-while-revalidate=300'
+    )
+  })
+
+  it('should send x-moov-cache-control with stale-while-revalidate and max-age when both are greater than 0', () => {
+    cache({ serverMaxAge: 1000, serverStaleWhileRevalidate: 300 })
+    expect(global.headers.header).toHaveBeenCalledWith(
+      'x-moov-cache-control',
+      'max-age=1000, stale-while-revalidate=300'
+    )
   })
 
   it('should not send s-maxage when serverMaxAge is 0', () => {

--- a/packages/react-storefront-moov-xdn/test/responseHeaderTransform.test.js
+++ b/packages/react-storefront-moov-xdn/test/responseHeaderTransform.test.js
@@ -68,32 +68,23 @@ describe('responseHeaderTransform', () => {
     global.env.__static_origin_path__ = true
     global.env.path = '/service-worker.js'
     responseHeaderTransform()
-    expect(headers.header('cache-control')).toBe(
-      `private, no-store, no-cache, s-maxage=${FAR_FUTURE}`
-    )
-  })
-
-  it('should cache the service worker on the server', () => {
-    global.env.__static_origin_path__ = true
-    global.env.path = '/service-worker.js'
-    responseHeaderTransform()
-    expect(headers.header('cache-control')).toBe(
-      `private, no-store, no-cache, s-maxage=${FAR_FUTURE}`
-    )
+    expect(headers.header('cache-control')).toBe(`private, no-store, no-cache`)
+    expect(headers.header('x-moov-cache-control')).toBe(`max-age=${FAR_FUTURE}`)
   })
 
   it('should cache pwa static assets on the client and server', () => {
     global.env.__static_origin_path__ = true
     global.env.path = '/pwa/main.js'
     responseHeaderTransform()
-    expect(headers.header('cache-control')).toBe(`max-age=${FAR_FUTURE}, s-maxage=${FAR_FUTURE}`)
+    expect(headers.header('cache-control')).toBe(`max-age=${FAR_FUTURE}`)
+    expect(headers.header('x-moov-cache-control')).toBe(`max-age=${FAR_FUTURE}`)
   })
 
-  it('should cache all other static assets on the server and not send a no-cache to the client', () => {
+  it('should cache all other static assets on the server', () => {
     global.env.__static_origin_path__ = true
     global.env.path = '/foo.png'
     responseHeaderTransform()
-    expect(headers.header('cache-control')).toBe(`s-maxage=${FAR_FUTURE}`)
+    expect(headers.header('x-moov-cache-control')).toBe(`max-age=${FAR_FUTURE}`)
   })
 
   it('should set a cookie when env.SET_COOKIE is set', () => {
@@ -140,19 +131,26 @@ describe('responseHeaderTransform', () => {
   it('should remove cache-control headers when status > 400', () => {
     global.env.MOOV_PWA_RESPONSE = {
       cookies: [],
-      cache: { serverMaxAge: 300, clientMaxAge: 300 },
+      cache: {
+        serverMaxAge: 300,
+        clientMaxAge: 300
+      },
       statusCode: 404
     }
 
     responseHeaderTransform()
 
     expect(headers.header('cache-control')).not.toBeDefined()
+    expect(headers.header('x-moov-cache-control')).not.toBeDefined()
   })
 
   it('should remove cache-control headers when redirecting with 302', () => {
     global.env.MOOV_PWA_RESPONSE = {
       cookies: [],
-      cache: { serverMaxAge: 300, clientMaxAge: 300 },
+      cache: {
+        serverMaxAge: 300,
+        clientMaxAge: 300
+      },
       redirectTo: '/',
       statusCode: 302
     }
@@ -160,6 +158,7 @@ describe('responseHeaderTransform', () => {
     responseHeaderTransform()
 
     expect(headers.header('cache-control')).not.toBeDefined()
+    expect(headers.header('x-moov-cache-control')).not.toBeDefined()
   })
 
   it('should set cache-control: private, no-store, no-cache when simulating a prefetch rejection', () => {
@@ -187,7 +186,7 @@ describe('responseHeaderTransform', () => {
       reset()
       global.env.path = path
       responseHeaderTransform()
-      expect(headers.header('cache-control')).toBe('s-maxage=86400')
+      expect(headers.header('x-moov-cache-control')).toBe('max-age=86400')
     })
   })
 
@@ -205,7 +204,7 @@ describe('responseHeaderTransform', () => {
       reset()
       global.env.path = path
       responseHeaderTransform({ cacheProxiedAssets: { serverMaxAge: 60 } })
-      expect(headers.header('cache-control')).toBe('s-maxage=60')
+      expect(headers.header('x-moov-cache-control')).toBe('max-age=60')
     })
   })
 

--- a/packages/react-storefront/src/router/cache.js
+++ b/packages/react-storefront/src/router/cache.js
@@ -34,7 +34,10 @@ import { SURROGATE_KEY } from './headers'
  * @param {Object} options
  * @param {Number} options.edge
  * @param {Number} options.edge.maxAgeSeconds The number of seconds the result should be cached on
- *  the server.  The maxAgeSeconds key is required when specifying a server config.
+ *  the server.  The maxAgeSeconds key is required when specifying a server config. You can `maxAgeSeconds` and `staleWhileRevalidateSeconds` together or separately.
+ * @param {Number} options.edge.staleWhileRevalidateSeconds The number of seconds before a cached response should be refreshed. When this option
+ *  is specified, a stale response will be served while a new response is being created.  This will lead to a greater percentage of requests being
+ *  served from the cache, but some users will receive stale content.  You can `maxAgeSeconds` and `staleWhileRevalidateSeconds` together or separately.
  * @param {Object} options.edge.key A custom cache key to override the default caching behavior.  Use `createCustomCacheKey()` to split the cache by
  *  headers and cookies, and/or normalize the cache by removing specific query parameters.
  * @param {Function} options.edge.surrogateKey A function that is passed the route params and the request and returns a surrogate key under which to cache the response.
@@ -77,13 +80,16 @@ export default function cache({ edge, server, client }) {
           response.cacheOnClient(true)
         }
       } else if (edge) {
-        if (edge.maxAgeSeconds) {
+        if (edge.maxAgeSeconds || edge.staleWhileRevalidateSeconds) {
           // For fetch to read
           env.shouldSendCookies =
             edge.key && edge.key.getCookieNames ? edge.key.getCookieNames() : false
 
           response.relayUpstreamCookies(false)
-          response.cacheOnServer(edge.maxAgeSeconds)
+          response.cacheOnServer({
+            maxAgeSeconds: edge.maxAgeSeconds,
+            staleWhileRevalidateSeconds: edge.staleWhileRevalidateSeconds
+          })
         }
 
         if (typeof edge.surrogateKey === 'function') {

--- a/packages/react-storefront/src/router/cache.js
+++ b/packages/react-storefront/src/router/cache.js
@@ -34,10 +34,9 @@ import { SURROGATE_KEY } from './headers'
  * @param {Object} options
  * @param {Number} options.edge
  * @param {Number} options.edge.maxAgeSeconds The number of seconds the result should be cached on
- *  the server.  The maxAgeSeconds key is required when specifying a server config. You can `maxAgeSeconds` and `staleWhileRevalidateSeconds` together or separately.
- * @param {Number} options.edge.staleWhileRevalidateSeconds The number of seconds before a cached response should be refreshed. When this option
- *  is specified, a stale response will be served while a new response is being created.  This will lead to a greater percentage of requests being
- *  served from the cache, but some users will receive stale content.  You can `maxAgeSeconds` and `staleWhileRevalidateSeconds` together or separately.
+ *  the server.  The maxAgeSeconds key is required when specifying a server config.
+ * @param {Number} options.edge.staleWhileRevalidateSeconds Use this in combination
+ *  with maxAgeSeconds to continue to serve cached responses after their time-to-live has expired.
  * @param {Object} options.edge.key A custom cache key to override the default caching behavior.  Use `createCustomCacheKey()` to split the cache by
  *  headers and cookies, and/or normalize the cache by removing specific query parameters.
  * @param {Function} options.edge.surrogateKey A function that is passed the route params and the request and returns a surrogate key under which to cache the response.

--- a/packages/react-storefront/src/router/cache.js
+++ b/packages/react-storefront/src/router/cache.js
@@ -85,7 +85,8 @@ export default function cache({ edge, server, client }) {
             edge.key && edge.key.getCookieNames ? edge.key.getCookieNames() : false
 
           response.relayUpstreamCookies(false)
-          response.cacheOnServer({
+
+          response.cacheAtEdge({
             maxAgeSeconds: edge.maxAgeSeconds,
             staleWhileRevalidateSeconds: edge.staleWhileRevalidateSeconds
           })

--- a/packages/react-storefront/test/router/cache.test.js
+++ b/packages/react-storefront/test/router/cache.test.js
@@ -51,8 +51,16 @@ describe('cache', () => {
     it('should support stale-while-revalidate', () => {
       const cache = require('../../src/router').cache
       const response = new Response()
-      cache({ edge: { staleWhileRevalidateSeconds: 1000 } }).fn({}, {}, response)
-      expect(response.cache).toEqual({ browserMaxAge: 0, serverStaleWhileRevalidate: 1000 })
+      cache({ edge: { maxAgeSeconds: 1000, staleWhileRevalidateSeconds: 1000 } }).fn(
+        {},
+        {},
+        response
+      )
+      expect(response.cache).toEqual({
+        browserMaxAge: 0,
+        serverMaxAge: 1000,
+        serverStaleWhileRevalidate: 1000
+      })
     })
 
     it('should support both maxage and stale-while-revalidate', () => {

--- a/packages/react-storefront/test/router/cache.test.js
+++ b/packages/react-storefront/test/router/cache.test.js
@@ -44,10 +44,30 @@ describe('cache', () => {
     it('should set response.cache', () => {
       const cache = require('../../src/router').cache
       const response = new Response()
-
       cache({ edge: { maxAgeSeconds: 1000 } }).fn({}, {}, response)
-
       expect(response.cache).toEqual({ browserMaxAge: 0, serverMaxAge: 1000 })
+    })
+
+    it('should support stale-while-revalidate', () => {
+      const cache = require('../../src/router').cache
+      const response = new Response()
+      cache({ edge: { staleWhileRevalidateSeconds: 1000 } }).fn({}, {}, response)
+      expect(response.cache).toEqual({ browserMaxAge: 0, serverStaleWhileRevalidate: 1000 })
+    })
+
+    it('should support both maxage and stale-while-revalidate', () => {
+      const cache = require('../../src/router').cache
+      const response = new Response()
+      cache({ edge: { staleWhileRevalidateSeconds: 1000, maxAgeSeconds: 2000 } }).fn(
+        {},
+        {},
+        response
+      )
+      expect(response.cache).toEqual({
+        browserMaxAge: 0,
+        serverMaxAge: 2000,
+        serverStaleWhileRevalidate: 1000
+      })
     })
 
     it('should support "server" in lieu of "edge" for backwards compatibility', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4445,13 +4445,6 @@ babel-plugin-react-docgen@^2.0.0:
     lodash "^4.17.10"
     react-docgen "^3.0.0-rc.1"
 
-babel-plugin-react-storefront@^6.0.3:
-  version "6.62.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-storefront/-/babel-plugin-react-storefront-6.62.2.tgz#fba1eee677660e847279c81974b09061d5a59298"
-  integrity sha512-llwmaMtQWB1HYtC4/FHWW+XIIB2CRk3TIvNMetysp9Gzv635KUK/rfH2ZNvgOG8phraOYsbGDu24Ng9rE1KfIA==
-  dependencies:
-    babel-core "^6.26.0"
-
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"


### PR DESCRIPTION
When configuring caching at edge, we used to send:

```js
cache-control: s-maxage: (time)
```

Now we'll send:

```js
x-moov-cache-control: max-age=(time), stale-while-revalidate=(time)
```
https://moovweb.atlassian.net/browse/PC-1029