### PR TITLE
Fix/infinite reloading in proxied pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ yarn release
 
 ### 6.70.1
 
-- Fixed infinite reloading in proxied pages. Not running handlers in from `Router.watch` anymore
+- Fixed infinite reloading in proxied pages. Not running handlers from `Router.watch` on page load anymore.
 
 ### 6.70.0
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ yarn release
 
 ## Changelog
 
+### 6.70.1
+
+- Fixed infinite reloading in proxied pages. Not running handlers in from `Router.watch` anymore
+
 ### 6.70.0
 
 - Added `zoomSrc` to `MediaTypeModel`. Use `zoomSrc` to specify a separate high-resolution URL to display when the user activates the pinch/zoom modal on the PDP.

--- a/packages/react-storefront/src/router/Router.js
+++ b/packages/react-storefront/src/router/Router.js
@@ -384,6 +384,11 @@ export default class Router extends EventEmitter {
         }
       }
 
+      // skip state handlers on initial hydration - we just need to run cache and we've already run it above
+      if (initialLoad) {
+        return
+      }
+
       for (let handler of handlers) {
         if (typeof handler === 'function') {
           handler = {

--- a/packages/react-storefront/src/router/Router.js
+++ b/packages/react-storefront/src/router/Router.js
@@ -609,7 +609,6 @@ export default class Router extends EventEmitter {
     const request = { path: pathname, search, query: qs.parse(search), method: 'GET' }
     const context = new ClientContext(request)
 
-    // this.runAll(request, context, { initialLoad: true }, window.initialState)
     this.emit('after', { request, response: context, initialLoad: true })
 
     return this

--- a/packages/react-storefront/src/router/Router.js
+++ b/packages/react-storefront/src/router/Router.js
@@ -384,11 +384,6 @@ export default class Router extends EventEmitter {
         }
       }
 
-      // skip state handlers on initial hydration - we just need to run cache and we've already run it above
-      if (initialLoad) {
-        return
-      }
-
       for (let handler of handlers) {
         if (typeof handler === 'function') {
           handler = {
@@ -614,7 +609,7 @@ export default class Router extends EventEmitter {
     const request = { path: pathname, search, query: qs.parse(search), method: 'GET' }
     const context = new ClientContext(request)
 
-    this.runAll(request, context, { initialLoad: true }, window.initialState)
+    // this.runAll(request, context, { initialLoad: true }, window.initialState)
     this.emit('after', { request, response: context, initialLoad: true })
 
     return this

--- a/packages/react-storefront/test/router/Router.test.js
+++ b/packages/react-storefront/test/router/Router.test.js
@@ -572,6 +572,15 @@ describe('Router:Node', function() {
   })
 
   describe('watch', () => {
+    it('should not call any handlers until history changes', () => {
+      process.env.MOOV_RUNTIME = 'client'
+      const history = createMemoryHistory()
+      history.push('/search')
+      const handler = jest.fn()
+      new Router().get('/search', handler).watch(history, jest.fn())
+      expect(handler).not.toHaveBeenCalled()
+    })
+
     it('should run route when history changes', () => {
       const history = createMemoryHistory()
       history.push('/')
@@ -785,7 +794,7 @@ describe('Router:Node', function() {
       expect(router.willCacheOnClient({ path: '/p/1.json' })).toBe(true)
     })
 
-    it.only('should return true if the route has a cache handler with client: true in the fallback route', () => {
+    it('should return true if the route has a cache handler with client: true in the fallback route', () => {
       router.fallback(cache({ client: true }))
       expect(router.willCacheOnClient({ path: '/p/1.json' })).toBe(true)
     })


### PR DESCRIPTION
A project had a proxyUpstream handler that was rendering the PWA in certain cases.  The page would keep reloading because router.watch used to run all handlers. This is no longer the case, and it appears that router.watch never needed to run all handlers, so the `runAll` call has been removed.

Fixes #336 