### PR TITLE
Fix issue where ssr jss is not removed on mount

### DIFF
--- a/packages/react-storefront/src/Server.js
+++ b/packages/react-storefront/src/Server.js
@@ -202,7 +202,6 @@ export default class Server {
           <body ${helmet.bodyAttributes.toString()}>
             ${await renderStyle({
               registry: sheetsRegistry,
-              id: 'ssr-css',
               minify: Boolean(amp)
             })}
             <noscript>

--- a/packages/react-storefront/src/renderers.js
+++ b/packages/react-storefront/src/renderers.js
@@ -135,7 +135,7 @@ export function renderScript(src, defer) {
  * @param  {String} options.id        ID for style tag
  * @return {String}                   Style HTML
  */
-export async function renderStyle({ registry, id = 'ssr-css', minify }) {
+export async function renderStyle({ registry, id = 'ssr-css-jss', minify }) {
   let css = registry.toString()
 
   // css might be undefined, e.g. after an error.


### PR DESCRIPTION
This fixes the issue where styling is broken after client side navigation.  The server side rendered css was not being removed on mount as it needs to be due to a change in our naming convention for the id of the style element to support hydration of multiple components with separate css prefixes.