### PR TITLE
Add support for image lazy load on horizontal scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ yarn release
 
 ## Changelog
 
+### 6.73.1
+
+- Add support for `lazyOffset` on the `<Image />` component when horizontal scrolling
+
 ### 6.73.0 [diff](https://github.com/moovweb/react-storefront/compare/v6.72.2...v6.73.0)
 
 - Improved support for A/B testing. You can now use `fromOrigin` and `redirectTo` route handlers when running A/B tests. This is done by moving the outer edge routing logic to the moov backend in oem.json

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ yarn release
 
 ## Changelog
 
-### 6.73.1
+### 6.75.0 [diff](https://github.com/moovweb/react-storefront/compare/v6.74.1...v6.75.0)
 
 - Add support for `lazyOffset` on the `<Image />` component when horizontal scrolling
 

--- a/packages/react-storefront/src/Image.js
+++ b/packages/react-storefront/src/Image.js
@@ -222,7 +222,12 @@ export default class Image extends Component {
           active={!loaded}
           onChange={this.lazyLoad}
           partialVisibility
-          offset={{ top: -lazyOffset, bottom: -lazyOffset }}
+          offset={{
+            top: -lazyOffset,
+            bottom: -lazyOffset,
+            left: -lazyOffset,
+            right: -lazyOffset
+          }}
         >
           {result}
         </VisibilitySensor>


### PR DESCRIPTION
**Purpose**
```
<Image
  contain
  className={classes.image}
  src={product.imageUrl}
  alt={product.name}
  lazy
  lazyOffset={600}
  optimize={{
    format: 'webp',
    quality: 80,
    width: 225,
  }}
/>
```
lazyOffset on the `<Image />` module only supports vertical scrolling and not horizontal. As a test, I changed the value to 2000 but all the images that were outside of the right of the viewport were not being loaded. This update adds support so that lazyOffset also works on horizontal scrolling.
