### PR TITLE
Adds input props to the SearchDrawer Input component

### DIFF
--- a/packages/react-storefront/src/SearchDrawer.js
+++ b/packages/react-storefront/src/SearchDrawer.js
@@ -202,7 +202,11 @@ export default class SearchDrawer extends Component {
     /**
      * Props to be applied to the underlying Drawer component
      */
-    drawerProps: PropTypes.object
+    drawerProps: PropTypes.object,
+    /**
+     * Props to be applied to the underlying Input component
+     */
+    inputProps: PropTypes.object
   }
 
   static defaultProps = {
@@ -252,7 +256,8 @@ export default class SearchDrawer extends Component {
       showClearButton,
       searchURL,
       searchFieldName,
-      amp
+      amp,
+      inputProps
     } = this.props
 
     const HideWhenEmpty = ({ children }) => (
@@ -291,7 +296,8 @@ export default class SearchDrawer extends Component {
                     onFocus={this.onInputFocus}
                     onChange={e => this.onChangeSearchText(e.target.value)}
                     inputProps={{
-                      'amp-bind': 'value=>rsfSearchDrawer.searchText'
+                      'amp-bind': 'value=>rsfSearchDrawer.searchText',
+                      ...inputProps
                     }}
                     on="input-debounced:AMP.setState({ rsfSearchDrawer: { searchText: rsfSearchDrawer.___moov_submitting ? rsfSearchDrawer.searchText : event.value } })"
                     disableUnderline

--- a/packages/react-storefront/test/__snapshots__/SearchDrawer.test.js.snap
+++ b/packages/react-storefront/test/__snapshots__/SearchDrawer.test.js.snap
@@ -8,7 +8,7 @@ exports[`SearchDrawer should render with no props 1`] = `
         <MuiThemeProviderOld theme={{...}}>
           <WithStyles(inject-SearchDrawer)>
             <inject-SearchDrawer classes={{...}}>
-              <SearchDrawer classes={{...}} search={{...}} history={{...}} theme={[undefined]} amp={false} placeholder="Search..." CloseButtonIcon={[Function: CloseButtonIcon]} blurBackground={true} searchButtonVariant="fab" searchURL="/search" searchFieldName="q" showClearButton={true} ampThumbnailWidth={120} ampThumbnailHeight={120} drawerProps={{...}}>
+              <SearchDrawer classes={{...}} search={{...}} history={{...}} theme={[undefined]} amp={false} placeholder="Search..." CloseButtonIcon={[Function: CloseButtonIcon]} blurBackground={true} searchButtonVariant="fab" searchURL="/search" searchFieldName="q" showClearButton={true} ampThumbnailWidth={120} ampThumbnailHeight={120} drawerProps={{...}} inputProps{{...}}>
                 <WithStyles(Drawer) open={true} anchor="bottom" className="RSFSearchDrawer-root-1" classes={{...}} ModalProps={{...}}>
                   <Drawer open={true} anchor="bottom" className="RSFSearchDrawer-root-1" ModalProps={{...}} theme={{...}} classes={{...}} elevation={16} transitionDuration={{...}} variant="temporary">
                     <WithStyles(Modal) BackdropProps={{...}} className="MuiDrawer-root-18 MuiDrawer-modal-29 RSFSearchDrawer-root-1" open={true} onClose={[undefined]} hideBackdrop={true}>


### PR DESCRIPTION
PR adds support to pass `inputProps` to the underlying Material UI `Input` component of the RSF `SearchDrawer` component.