### PR TITLE
Added handling for appending `link` headers to existing preload headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ yarn release
 
 ## Changelog
 
+### 6.83.1 [diff](https://github.com/moovweb/react-storefront/compare/v6.83.0...v6.83.1)
+
+- Added handling for appending `link` headers to existing preload headers
+
 ### 6.83.0 [diff](https://github.com/moovweb/react-storefront/compare/v6.82.8...v6.83.0)
 
 - Added the ability for the Moovweb XDN to pass in a route index from the edge using the `x-xdn-route` header.

--- a/packages/react-storefront/src/Server.js
+++ b/packages/react-storefront/src/Server.js
@@ -186,7 +186,14 @@ export default class Server {
       // Set prefetch headers so that our scripts will be fetched
       // and loaded as fast as possible
       if (this.sendPreloadHeaders) {
-        response.set('link', scripts.map(renderPreloadHeader).join(', '))
+        const linkHeader = response.get('link')
+        const preloadHeader = scripts.map(renderPreloadHeader)
+
+        // append any existing `link` header
+        if (linkHeader) {
+          preloadHeader.push(linkHeader)
+        }
+        response.set('link', preloadHeader.join(', '))
       }
 
       html = `

--- a/packages/react-storefront/test/Server.test.js
+++ b/packages/react-storefront/test/Server.test.js
@@ -89,6 +89,17 @@ describe('Server', () => {
       expect(exported.MOOV_PWA_RESPONSE.headers.link).toBe('</pwa/main.js>; rel=preload; as=script')
     })
 
+    it('should append prefetch headers', async () => {
+      global.env.path = '/test'
+      request = new Request()
+      response = new Response(request)
+      response.set('link', '</foo.js>; rel=preload; as=script')
+      await new Server({ theme, model, router, blob, globals, App }).serve(request, response)
+      expect(exported.MOOV_PWA_RESPONSE.headers.link).toBe(
+        '</pwa/main.js>; rel=preload; as=script, </foo.js>; rel=preload; as=script'
+      )
+    })
+
     it('should render scripts', async () => {
       global.env.path = '/test'
       request = new Request()


### PR DESCRIPTION
If a `link` header is set in the response, it is overwritten when the Server sends the preload headers. This change appends a set `link` header to the list of preload headers in the response.